### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/de.hummdudel.Libellus.json
+++ b/de.hummdudel.Libellus.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "de.hummdudel.Libellus",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "de.hummdudel.Libellus",
     "finish-args" : [
@@ -10,17 +10,6 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland"
-    ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
     ],
     "modules" : [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands