### PR TITLE
Update the runtime to 50, and more

### DIFF
--- a/de.hummdudel.Libellus.json
+++ b/de.hummdudel.Libellus.json
@@ -1,11 +1,8 @@
 {
     "app-id" : "de.hummdudel.Libellus",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
-    "sdk-extensions" : [
-        "org.freedesktop.Sdk.Extension.vala"
-    ],
     "command" : "libellus",
     "finish-args" : [
         "--share=network",
@@ -13,22 +10,6 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland"
-    ],
-    "build-options" : {
-        "append-path" : "/usr/lib/sdk/vala/bin",
-        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
-    },
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "/share/vala",
-        "*.la",
-        "*.a"
     ],
     "modules" : [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Drop Vala SDK, which GNOME runtime already provides